### PR TITLE
Fix cache persistence of costs and runtime

### DIFF
--- a/bench/index.ts
+++ b/bench/index.ts
@@ -652,7 +652,8 @@ export async function testRunner(options: TestRunnerOptions) {
               );
             }
 
-            const duration = Date.now() - startTime;
+            // Use the original cached duration, not the time to retrieve from cache
+            const duration = testRun.reuseFrom.duration || 0;
             const reused = testRun.reuseFrom;
             const text = reused.text;
             const correct = isCorrect({
@@ -912,7 +913,8 @@ export async function testRunner(options: TestRunnerOptions) {
           );
         }
 
-        const duration = Date.now() - startTime;
+        // Use the original cached duration, not the time to retrieve from cache
+        const duration = r.duration || 0;
         const text = r.text;
         const correct = isCorrect({
           answers: testRun.answers,


### PR DESCRIPTION
Fix incorrect duration calculation when reusing cached benchmark results to ensure accurate run time persistence.

---
<a href="https://cursor.com/background-agent?bcId=bc-7de3d157-3451-41d1-8c49-650ba8b00b73">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7de3d157-3451-41d1-8c49-650ba8b00b73">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>