### PR TITLE
Add description of what the skatebench benchmark tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # skatebench
 
+A benchmark that tests LLMs on skateboarding trick terminology - whether they can correctly name tricks based on technical descriptions.
+
+## What it tests
+
+The benchmark evaluates if AI models can identify skateboard tricks from their descriptions. For example:
+
+**Test prompt**: "Board spins 360 degrees backside and flips in the kickflip direction. The skater does not spin."  
+**Correct answers**: "tre flip" or "360 flip"  
+**Failure if contains**: "backside 360 kickflip", "360 heelflip" (common mistakes)
+
+## Installation
+
 To install dependencies:
 
 ```bash


### PR DESCRIPTION
Added a clear explanation at the top of the README describing that this benchmark tests LLMs on skateboarding trick terminology, with a concrete example of a test case showing the prompt, correct answers, and failure conditions.

🤖 Generated with [Claude Code](https://claude.ai/code)